### PR TITLE
Add --shell-auto-fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ By default, `<command>` will be installed prior to execution. An optional `@vers
 
 * `-c <string>` - Execute `<string>` with delayed environment variable evaluation.
 
+* `--shell-auto-fallback [shell]` - Generates shell code to override your shell's "command not found" handler with one that calls `npx`. Tries to figure out your shell, or you can pass its name (either `bash`, `fish`, or `zsh`) as an option. See below for how to install.
+
 * `-v, --version` - Show the current npx version.
 
 ## EXAMPLES
@@ -56,6 +58,30 @@ $ cat package.json
 $ npx -D webpack -- ...
 $ cat package.json
 ...webpack added to "devDependencies"
+```
+
+## SHELL AUTO FALLBACK
+
+To install permanently, add the relevant line to your `~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`, or as needed. To install just for the shell session, simply run the line.
+
+Be warned that this _will_ send (almost) all your missed commands over the internet, then fetch and execute code automatically.
+
+### For Bash:
+
+```
+$ source <(npx --shell-auto-fallback bash)
+```
+
+### For Fish:
+
+```
+$ source (npx --shell-auto-fallback fish | psub)
+```
+
+### For Zsh:
+
+```
+$ source <(npx --shell-auto-fallback zsh)
 ```
 
 ## ACKNOWLEDGEMENTS

--- a/auto-fallback.js
+++ b/auto-fallback.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const POSIX = `
+command_not_found_handler() {
+  # Do not run within a pipe
+  if test ! -t 1; then
+    echo "command not found: $1"
+    return 127
+  fi
+
+  echo "Trying with npx..."
+  npx $*
+  return $?
+}`
+
+const FISH = `
+function __fish_command_not_found_on_interactive --on-event fish_prompt
+  functions --erase __fish_command_not_found_handler
+  functions --erase __fish_command_not_found_setup
+
+  function __fish_command_not_found_handler --on-event fish_command_not_found
+    echo "Trying with npx..."
+    npx $argv
+  end
+
+  functions --erase __fish_command_not_found_on_interactive
+end`
+
+module.exports = function autoFallback (shell) {
+  const { BASH_VERSION, SHELL, ZSH_VERSION } = process.env
+
+  if (shell === 'bash' || BASH_VERSION || /bash/.test(SHELL)) {
+    return POSIX.replace('handler()', 'handle()')
+  }
+
+  if (shell === 'zsh' || ZSH_VERSION || /zsh/.test(SHELL)) {
+    return POSIX
+  }
+
+  if (shell === 'fish' || /fish/.test(SHELL)) {
+    return FISH
+  }
+
+  console.error('Only Bash, Zsh, and Fish shells are supported :(')
+  process.exit(1)
+}

--- a/auto-fallback.js
+++ b/auto-fallback.js
@@ -27,19 +27,17 @@ function __fish_command_not_found_on_interactive --on-event fish_prompt
 end`
 
 module.exports = function autoFallback (shell) {
-  const BASH_VERSION = process.env.BASH_VERSION
-  const SHELL = process.env.SHELL
-  const ZSH_VERSION = process.env.ZSH_VERSION
+  const SHELL = process.env.SHELL || ''
 
-  if (shell === 'bash' || BASH_VERSION || /bash/.test(SHELL)) {
+  if (shell === 'bash' || SHELL.includes('bash')) {
     return POSIX.replace('handler()', 'handle()')
   }
 
-  if (shell === 'zsh' || ZSH_VERSION || /zsh/.test(SHELL)) {
+  if (shell === 'zsh' || SHELL.includes('zsh')) {
     return POSIX
   }
 
-  if (shell === 'fish' || /fish/.test(SHELL)) {
+  if (shell === 'fish' || SHELL.includes('fish')) {
     return FISH
   }
 

--- a/auto-fallback.js
+++ b/auto-fallback.js
@@ -27,7 +27,9 @@ function __fish_command_not_found_on_interactive --on-event fish_prompt
 end`
 
 module.exports = function autoFallback (shell) {
-  const { BASH_VERSION, SHELL, ZSH_VERSION } = process.env
+  const BASH_VERSION = process.env.BASH_VERSION
+  const SHELL = process.env.SHELL
+  const ZSH_VERSION = process.env.ZSH_VERSION
 
   if (shell === 'bash' || BASH_VERSION || /bash/.test(SHELL)) {
     return POSIX.replace('handler()', 'handle()')

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 
 const BB = require('bluebird')
 
+const autoFallback = require('./auto-fallback.js')
 const cp = require('child_process')
 const getPrefix = require('./get-prefix.js')
 const parseArgs = require('./parse-args.js')
@@ -18,6 +19,12 @@ updateNotifier({pkg}).notify()
 main(parseArgs())
 
 function main (argv) {
+  const shell = argv['shell-auto-fallback']
+  if (shell || shell === '') {
+    console.log(autoFallback(shell))
+    process.exit(0)
+  }
+
   if (!argv.command || !argv.package) {
     console.error('\nERROR: You must supply a command.\n')
     yargs.showHelp()

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ main(parseArgs())
 
 function main (argv) {
   const shell = argv['shell-auto-fallback']
-  if (shell || shell === '') {
+  if (shell) {
     console.log(autoFallback(shell))
     process.exit(0)
   }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ main(parseArgs())
 
 function main (argv) {
   const shell = argv['shell-auto-fallback']
-  if (shell) {
+  if (shell || shell === '') {
     console.log(autoFallback(shell))
     process.exit(0)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npx",
-  "version": "1.0.2",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/parse-args.js
+++ b/parse-args.js
@@ -64,10 +64,9 @@ function parseArgs () {
     describe: 'execute string as if inside `npm run-script`'
   })
   .option('shell-auto-fallback', {
-    choices: ['detect', 'bash', 'fish', 'zsh'],
+    choices: ['', 'bash', 'fish', 'zsh'],
     describe: 'generate shell code to use npx as the "command not found" fallback',
-    default: 'detect',
-    requiresArg: false,
+    requireArg: false,
     type: 'string'
   })
   .version()

--- a/parse-args.js
+++ b/parse-args.js
@@ -63,10 +63,9 @@ function parseArgs () {
     describe: 'execute string as if inside `npm run-script`'
   })
   .option('shell-auto-fallback', {
-    choices: ['', 'bash', 'fish', 'zsh'],
+    choices: ['detect', 'bash', 'fish', 'zsh'],
     describe: 'generate shell code to use npx as the "command not found" fallback',
-    default: '',
-    defaultDescription: 'detect',
+    default: 'detect',
     requiresArg: false,
     type: 'string'
   })

--- a/parse-args.js
+++ b/parse-args.js
@@ -3,8 +3,7 @@
 const npa = require('npm-package-arg')
 const yargs = require('yargs')
 
-const usage = `$0 [--package|-p <package>] [--cache <path>] [--save-dev|-D] [--save-prod|-P] [--save-optional|-O] [--save-bundle|-B] [--save-exact|-E] [--global|-g] [--prefix|-C] [--userconfig <path>] [-c <string>] [--version|-v] [--] <command>[@version] [command-arg]...
-$0 --shell-auto-fallback [<shell>]`
+const usage = `$0 [--package|-p <package>] [--cache <path>] [--save-dev|-D] [--save-prod|-P] [--save-optional|-O] [--save-bundle|-B] [--save-exact|-E] [--global|-g] [--prefix|-C] [--userconfig <path>] [-c <string>] [--shell-auto-fallback [shell]] [--version|-v] [--] <command>[@version] [command-arg]...`
 
 module.exports = parseArgs
 function parseArgs () {

--- a/parse-args.js
+++ b/parse-args.js
@@ -3,7 +3,8 @@
 const npa = require('npm-package-arg')
 const yargs = require('yargs')
 
-const usage = `$0 [--package|-p <package>] [--cache <path>] [--save-dev|-D] [--save-prod|-P] [--save-optional|-O] [--save-bundle|-B] [--save-exact|-E] [--global|-g] [--prefix|-C] [--userconfig <path>] [-c <string>] [--version|-v] [--] <command>[@version] [command-arg]...`
+const usage = `$0 [--package|-p <package>] [--cache <path>] [--save-dev|-D] [--save-prod|-P] [--save-optional|-O] [--save-bundle|-B] [--save-exact|-E] [--global|-g] [--prefix|-C] [--userconfig <path>] [-c <string>] [--version|-v] [--] <command>[@version] [command-arg]...
+$0 --shell-auto-fallback [<shell>]`
 
 module.exports = parseArgs
 function parseArgs () {

--- a/parse-args.js
+++ b/parse-args.js
@@ -62,6 +62,14 @@ function parseArgs () {
     type: 'string',
     describe: 'execute string as if inside `npm run-script`'
   })
+  .option('shell-auto-fallback', {
+    choices: ['', 'bash', 'fish', 'zsh'],
+    describe: 'generate shell code to use npx as the "command not found" fallback',
+    default: '',
+    defaultDescription: 'detect',
+    requiresArg: false,
+    type: 'string'
+  })
   .version()
   .alias('version', 'v')
 

--- a/test/auto-fallback.js
+++ b/test/auto-fallback.js
@@ -1,0 +1,112 @@
+'use strict'
+
+const exec = require('child_process').exec
+const test = require('tap').test
+
+test('not called with option', (t) =>
+  exec('node .', (err, stdout, stderr) => {
+    t.equal(err.code, 1)
+    t.notOk(stdout)
+    t.match(stderr, /--shell-auto-fallback/)
+    t.end()
+  })
+)
+
+test('detect: SHELL ~= fish', (t) =>
+  exec('node . --shell-auto-fallback', {
+    env: {
+      SHELL: '/usr/bin/fish'
+    }
+  }, (err, stdout, stderr) => {
+    if (err) { throw err }
+    t.match(stdout, /function __fish_command_not_found/)
+    t.notOk(stderr)
+    t.end()
+  })
+)
+
+test('detect: SHELL ~= bash', (t) =>
+  exec('node . --shell-auto-fallback', {
+    env: {
+      SHELL: '/bin/bash'
+    }
+  }, (err, stdout, stderr) => {
+    if (err) { throw err }
+    t.match(stdout, /command_not_found_handle\(/)
+    t.notOk(stderr)
+    t.end()
+  })
+)
+
+test('detect: SHELL ~= zsh', (t) =>
+  exec('node . --shell-auto-fallback', {
+    env: {
+      SHELL: '/usr/local/bin/zsh'
+    }
+  }, (err, stdout, stderr) => {
+    if (err) { throw err }
+    t.match(stdout, /command_not_found_handler\(/)
+    t.notOk(stderr)
+    t.end()
+  })
+)
+
+test('detect: no SHELL', (t) =>
+  exec('node . --shell-auto-fallback', {
+    env: {}
+  }, (err, stdout, stderr) => {
+    t.equal(err.code, 1)
+    t.notOk(stdout)
+    t.match(stderr, /Only .+ shells are supported :\(/)
+    t.end()
+  })
+)
+
+test('detect: SHELL ~= unsupported', (t) =>
+  exec('node . --shell-auto-fallback', {
+    env: {
+      SHELL: '/sbin/nope'
+    }
+  }, (err, stdout, stderr) => {
+    t.equal(err.code, 1)
+    t.notOk(stdout)
+    t.match(stderr, /Only .+ shells are supported :\(/)
+    t.end()
+  })
+)
+
+test('given: fish', (t) =>
+  exec('node . --shell-auto-fallback fish', (err, stdout, stderr) => {
+    if (err) { throw err }
+    t.match(stdout, /function __fish_command_not_found/)
+    t.notOk(stderr)
+    t.end()
+  })
+)
+
+test('given: bash', (t) =>
+  exec('node . --shell-auto-fallback bash', (err, stdout, stderr) => {
+    if (err) { throw err }
+    t.match(stdout, /command_not_found_handle\(/)
+    t.notOk(stderr)
+    t.end()
+  })
+)
+
+test('given: zsh', (t) =>
+  exec('node . --shell-auto-fallback zsh', (err, stdout, stderr) => {
+    if (err) { throw err }
+    t.match(stdout, /command_not_found_handler\(/)
+    t.notOk(stderr)
+    t.end()
+  })
+)
+
+test('given: unsupported', (t) =>
+  exec('node . --shell-auto-fallback nope', (err, stdout, stderr) => {
+    t.equal(err.code, 1)
+    t.notOk(stdout)
+    t.match(stderr, /Invalid values:\s+Argument: shell-auto-fallback/)
+    t.end()
+  })
+)


### PR DESCRIPTION
Generates shell code that hooks into the "command not found" mechanism
and attempts to run the command with npx instead of failing. The option
has an optional argument that forces generation of a particular variant,
otherwise it attempts to autodetect the shell.

As Seen On Twitter[™](https://twitter.com/passcod/status/869469928474107906)