### PR TITLE
fix(npm): use --userconfig when querying for npm cache config

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function getNpmCache (opts) {
     if (opts.userconfig) {
       args.push('--userconfig', opts.userconfig)
     }
-    return child.exec(npmPath, ['config', 'get', 'cache'])
+    return child.exec(npmPath, args)
   }).then(cache => cache.trim())
 }
 


### PR DESCRIPTION
When `npx` runs `npm config get cache`, the param `--userconfig` was being checked and prepared, but in the end not forwarded to `npm`. This PR fixes that.