### PR TITLE
Add German translations

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -6,7 +6,7 @@
   "Path to user npmrc.": "Pfad zu npmrc im Benutzerverzeichnis.",
   "Execute string as if inside `npm run-script`.": "Führe Zeichenkette aus, als wäre sie innerhalb von `npm run-script`.",
   "Shell to execute the command with, if any.": "Shell, mit der Programme ausgeführt werden soll, wenn überhaupt.",
-  "Generate shell code to use npx as the \"command not found\" fallback.": "Erzeuge Shellcode um npx als Alternative zu \"Programm konnte nicht gefunden werden\" zu benutzen.",
+  "Generate shell code to use npx as the \"command not found\" fallback.": "Erzeuge Shellcode, um npx als Alternative zu \"Programm konnte nicht gefunden werden\" zu benutzen.",
   "Ignores existing binaries in $PATH, or in the local project. This forces npx to do a temporary install and use the latest version.": "Ignoriere bestehende Programme innerhalb von $PATH oder im lokalen Projekt. Dies zwingt npx dazu, die neuste Version herunterzuladen und zu benutzen.",
   "npm binary to use for internal operations.": "npm-Programm für die interne Benutzung.",
   "For the full documentation, see the manual page for npx(1).": "In der Manpage npx(1) ist die gesamte Dokumentation einzusehen.",
@@ -15,5 +15,15 @@
   "Command failed: %s %s": "Befehl fehlgeschlagen: %s %s",
   "Install for %s failed with code %s": "Die Installation von %s ist mit dem Code %s fehlgeschlagen",
   "%s not found. Trying with npx...": "%s konnte nicht gefunden werden. Versuche mit npx...",
-  "command not found: %s": "Programm konnte nicht gefunden werden: %s"
+  "command not found: %s": "Programm konnte nicht gefunden werden: %s",
+  "options": "Optionen",
+  "command": "Befehl",
+  "version": "Version",
+  "command-arg": "Befehlsargument",
+  "command-string": "Befehlszeichenkette",
+  "shell": "Shell",
+  "package": "Paket",
+  "npx: installed %s in %ss": "npx: Installierte %s in %ss",
+  "Suppress output from npx itself. Subcommands will not be affected.": "Unterdrücke Output von npx. Unterbefehle sind nicht davon betroffen.",
+  "Extra node argument when calling a node binary.": "Extra node Argument, wenn eine node ausführbare Binärdatei gerufen ist."
 }


### PR DESCRIPTION
Addresses #39 for German (de).

@zkat, Would be good for another native speaker to review, but I think it's probably ~90% accurate ("deutsche Sprache, schwere Sprache") - definitely enough to inform what's meant and what's going on. 

What do you set in an environment to use a locale other than the default?