### PR TITLE
Change fallback wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For example:
 
 ```
 $ npm@4 --version
-(stderr) npm@4 not found. Trying with npx...
+(stderr) Running npm@4 with npx...
 4.6.1
 $ asdfasdfasf
 zsh: command not found: asfdasdfasdf

--- a/locales/en.json
+++ b/locales/en.json
@@ -14,7 +14,7 @@
   "\nERROR: You must supply a command.\n": "\nERROR: You must supply a command.\n",
   "Command failed: %s %s": "Command failed: %s %s",
   "Install for %s failed with code %s": "Install for %s failed with code %s",
-  "%s not found. Trying with npx...": "%s not found. Trying with npx...",
+  "%s not found. Trying with npx...": "Running %s with npx...",
   "command not found: %s": "command not found: %s",
   "options": "options",
   "command": "command",


### PR DESCRIPTION
Makes the shell auto-fallback wording less scary for the common case of using npx to run otherwise globally-installed commands like `bower` or `ember`

I'm not entirely convinced the wording is correct, and also I wasn't sure whether to change just the locale file or also the base string.