### PR TITLE
fix(exec): fixed unix binary pathing issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ function installPackages (specs, prefix, opts) {
       return opts.npm
     }
   }).then(npmPath => {
-    return child.escapeArg(npmPath, true)
+    return process.platform === 'win32' ? child.escapeArg(npmPath, true) : npmPath
   }).then(npmPath => {
     return child.spawn(npmPath, args, {
       stdio: [0, 'pipe', opts.q ? 'ignore' : 2]


### PR DESCRIPTION
with special characters, which were incorrectly escaped with surrounding
quotation marks causing child_process.spawn to throw an ENOENT error.

---

While upgrading `npm` in our homebrew formulaes to v5.4.2 we found out, that our `npx` test started to regress on our versioned formulas (node@6 and node@4) with the following error: `spawn '/usr/local/Cellar/node@6/6.11.4/bin/node' ENOENT` (Refs: https://github.com/Homebrew/homebrew-core/pull/19348#issuecomment-336063778). After bisecting `npx` versions I've found out that the regression was introduced between `npx@9.2.0` and `npx@9.2.1` in https://github.com/zkat/npx/commit/761dfe9bd73e0aca8170d23187e4fbce0ef7a647. This [commit changed](https://github.com/zkat/npx/commit/761dfe9bd73e0aca8170d23187e4fbce0ef7a647#diff-168726dbe96b3ce427e7fedce31bb0bcR221) the path passed as the [(first) command argument to `child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) in `installPackages` from being the path to `npm` to being the path to the `node` executable.

This issue was only reproducible for our versioned formulas because only these contain a special character in their path to node (e.g. `/usr/local/Cellar/node@6/6.11.4/bin/node`) and only in this case [`child.escapeArg`](https://github.com/zkat/npx/blob/52c2be24b74aca25d71ae907e461552a3f2af072/index.js#L235) will [surround the path with single quotation marks](https://github.com/zkat/npx/blob/52c2be24b74aca25d71ae907e461552a3f2af072/child.js#L84) (e.g.`npmPath === '\'/usr/local/Cellar/node@6/6.11.4/bin/node\''`). Unfortunately `child_process.spawn` doesn't accept paths surrounded with quotation marks (`'`) on Unix and throws an `spawn '/usr/local/Cellar/node@6/6.11.4/bin/node' ENOENT` error (Note that the `'` do not mark the beginning or ending of the path string here, but are actual considered part of the actual path.)

This PR fixes the issue by only running `child.escapeArg` on Windows (where it is needed to support for examples paths containing spaces, but on Unix even spaces in the path string aren't a problem for `child_process.spawn`).

An alternative fix would be to remove the quotations marks [in line 84](https://github.com/zkat/npx/blob/52c2be24b74aca25d71ae907e461552a3f2af072/child.js#L84) in `child.escapeArg`, but because `child.escapeArg` is also used in other places in the code base, I'm not sure if this would cause other side effects.
