### PR TITLE
Feature: Update yargs to 10.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "update-notifier": "^2.2.0",
     "which": "^1.2.14",
     "y18n": "^3.2.1",
-    "yargs": "^8.0.2"
+    "yargs": "^10.0.3"
   },
   "devDependencies": {
     "cross-env": "^5.0.1",

--- a/parse-args.js
+++ b/parse-args.js
@@ -223,7 +223,6 @@ function yargsParser (argv, defaultNpm) {
     type: 'string',
     describe: Y()`Extra node argument when calling a node binary.`
   })
-  .version(() => require('./package.json').version)
   .alias('version', 'v')
   .help()
   .alias('help', 'h')


### PR DESCRIPTION
* There is only few breaking changes between yargs 8x and 10x as per the [chagnelog](https://github.com/yargs/yargs/blob/master/CHANGELOG.md#breaking-changes)
* in that breaking change, they [made](https://github.com/yargs/yargs/commit/1ef44e03ef1a2779f92bd979984a6bab3a671ee9#diff-0f426376b964e609c5c4618eb8bed3b2L1264) following change
	- If we need to specify custom version other that one taken from package.json,
we can specify it as argument passed to `version()` function instead of passing a function which returns a custom version
	- **version** argument is enabled by default
* Actually, npx is taking version from package.json. So we don't have to do anything special

