### PR TITLE
Fix #100 (Improved escaping of spaced paths on Windows)

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,11 @@ function buildArgs (specs, prefix, opts) {
 
 module.exports._installPackages = installPackages
 function installPackages (specs, prefix, opts) {
-  const args = buildArgs(specs, prefix, opts)
+  const args = buildArgs(
+    specs,
+    process.platform === 'win32' ? child.escapeArg(prefix) : prefix,
+    opts
+  )
   return findNodeScript(opts.npm, {isLocal: true}).then(npmPath => {
     if (npmPath) {
       args.unshift(

--- a/test/index.js
+++ b/test/index.js
@@ -169,7 +169,7 @@ test('installPackages unit', t => {
       throw new Error('should not have failed')
     })
   }).then(() => {
-    return installPkgs(['cowsay@latest'], 'my spaced prefix', {
+    return installPkgs(['installme@latest'], 'my spaced prefix', {
       npm: NPM_PATH
     }).then((results) => {
       if (isWindows) {

--- a/test/index.js
+++ b/test/index.js
@@ -113,6 +113,8 @@ test('installPackages unit', t => {
           return '\'/f@ke_/path to/node\''
         } else if (arg === 'C:\\f@ke_\\path to\\node'){
           return '"C:\\f@ke_\\path to\\node"'
+        } else if (arg === 'my spaced prefix'){
+          return '"my spaced prefix"'
         }
         return arg
       }
@@ -165,6 +167,16 @@ test('installPackages unit', t => {
     }, (e) => {
       process.argv[0] = nodePath
       throw new Error('should not have failed')
+    })
+  }).then(() => {
+    return installPkgs(['cowsay@latest'], 'my spaced prefix', {
+      npm: NPM_PATH
+    }).then((results) => {
+      if (isWindows) {
+        t.equal(results[1][5], '"my spaced prefix"', 'prefix is escaped on Windows')
+      } else {
+        t.equal(results[1][5], 'my spaced prefix', 'prefix is unchanged on not-Windows')
+      }
     })
   })
 })


### PR DESCRIPTION
Fixes: #100 

I went through the `npx` operations on a Windows 10 user account named "name with spaces" in it to figure out where the issue arises. Since `npm` proper *does* work with accounts with spaces, I figured it was an `npx` issue.

The script crashes during the running of the child `npm` process to install the packages. Inspecting the arguments provided to the `installPackages()` function, I decided to try escaping the path in the `prefix` argument using the `child.escapeArg()` function. I left the `asPath` as `false` because setting it to `true` led to the script hanging for some reason.

With these changes, I can run `npx` where before I couldn't:

*(Running in my `npx` local repository)*
**Before**
```
C:\Users\name with spaces\dev\npx> node .\test\util\npx-bin.js cowsay hey
Error: EPERM: operation not permitted, mkdir 'C:\Users\name'
TypeError: Cannot read property 'get' of undefined
    at errorHandler (C:\Users\name with spaces\dev\npx\node_modules\npm\lib\utils\error-handler.js:213:18)
    at C:\Users\name with spaces\dev\npx\node_modules\npm\bin\npm-cli.js:83:20
    at cb (C:\Users\name with spaces\dev\npx\node_modules\npm\lib\npm.js:215:22)
    at C:\Users\name with spaces\dev\npx\node_modules\npm\lib\npm.js:253:24
    at C:\Users\name with spaces\dev\npx\node_modules\npm\lib\config\core.js:81:7
    at Array.forEach (<anonymous>)
    at C:\Users\name with spaces\dev\npx\node_modules\npm\lib\config\core.js:80:13
    at f (C:\Users\name with spaces\dev\npx\node_modules\npm\node_modules\once\once.js:25:25)
    at afterExtras (C:\Users\name with spaces\dev\npx\node_modules\npm\lib\config\core.js:178:20)
    at C:\Users\name with spaces\dev\npx\node_modules\npm\node_modules\mkdirp\index.js:47:53
C:\Users\name with spaces\dev\npx\node_modules\npm\lib\utils\error-handler.js:213
  if (npm.config.get('json')) {
                 ^

TypeError: Cannot read property 'get' of undefined
    at process.errorHandler (C:\Users\name with spaces\dev\npx\node_modules\npm\lib\utils\error-handler.js:213:18)
    at process.emit (events.js:159:13)
    at process._fatalException (bootstrap_node.js:387:26)
Install for cowsay@latest failed with code 7
```
**After**
```
C:\Users\name with spaces\dev\npx> node .\test\util\npx-bin.js cowsay hey
npx: installed 9 in 3.593s
 _____
< hey >
 -----
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```
I included a unit test for `installPackages()` for this new behavior, modeled after the other previously-implemented tests.