### PR TITLE
feat(node): Add `--node-module` support to resolve `node_modules` in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ If a full specifier is included, or if `--package` is used, npx will always use 
 
 * `-n, --node-arg` - Extra node argument to supply to node when binary is a node script. You can supply this option multiple times to add more arguments.
 
+* `-m, --node-module` - Resolve parents' `node_modules` directories in the way of Node.JS.
+
 * `-v, --version` - Show the current npx version.
 
 ## EXAMPLES

--- a/get-prefix.js
+++ b/get-prefix.js
@@ -5,7 +5,22 @@ const promisify = require('./util.js').promisify
 const path = require('path')
 const statAsync = promisify(require('fs').stat)
 
-module.exports = getPrefix
+module.exports.getPrefix = getPrefix
+module.exports.getPrefixes = getPrefixes
+
+function getPrefixes (cwd) {
+  const result = []
+  const getFromTree = current => getPrefix(current)
+    .then(prefix => {
+      if (!prefix) {
+        return result
+      }
+      result.push(prefix)
+      return getFromTree(path.dirname(prefix))
+    })
+  return getFromTree(cwd)
+}
+
 function getPrefix (root) {
   const original = root = path.resolve(root)
   while (path.basename(root) === 'node_modules') {

--- a/locales/en.json
+++ b/locales/en.json
@@ -26,5 +26,6 @@
   "npx: installed %s in %ss": "npx: installed %s in %ss",
   "Suppress output from npx itself. Subcommands will not be affected.": "Suppress output from npx itself. Subcommands will not be affected.",
   "Extra node argument when calling a node binary.": "Extra node argument when calling a node binary.",
-  "Always spawn a child process to execute the command.": "Always spawn a child process to execute the command."
+  "Always spawn a child process to execute the command.": "Always spawn a child process to execute the command.",
+  "Resolve parents' `node_modules` directories in the way of Node.JS.": "Resolve parents' `node_modules` directories in the way of Node.JS."
 }

--- a/parse-args.js
+++ b/parse-args.js
@@ -227,6 +227,11 @@ function yargsParser (argv, defaultNpm) {
       type: 'string',
       describe: Y()`Extra node argument when calling a node binary.`
     })
+    .option('node-module', {
+      alias: 'm',
+      type: 'boolean',
+      describe: Y()`Resolve parents' \`node_modules\` directories in the way of Node.JS.`
+    })
     .version()
     .alias('version', 'v')
     .help()


### PR DESCRIPTION
feat(node): Add `--node-module` support to resolve `node_modules` in the way of Node.JS (#118)

```
├── a
│   └── b
│       ├── c
│       │   └── d
│       └── node_modules
└── node_modules
```

When using `npx --node-module` in `path/a/b/c/d` the `$PATH` will be `path/a/b/node_modules/.bin:path/node_modules/.bin:$PATH`

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
