### PR TITLE
Add return promise to the Module.runMain() branch.

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ function installPackages (specs, prefix, opts) {
 module.exports._execCommand = execCommand
 function execCommand (_existing, argv) {
   return findNodeScript(_existing, argv).then(existing => {
-    if (existing && !argv.nodeArg && !argv.shell && existing !== process.argv[1]) {
+    if (existing && !argv.alwaysSpawn && !argv.nodeArg && !argv.shell && existing !== process.argv[1]) {
       const Module = require('module')
       // let it take over the process. This means we can skip node startup!
       if (!argv.noYargs) {

--- a/locales/en.json
+++ b/locales/en.json
@@ -25,5 +25,6 @@
   "package": "package",
   "npx: installed %s in %ss": "npx: installed %s in %ss",
   "Suppress output from npx itself. Subcommands will not be affected.": "Suppress output from npx itself. Subcommands will not be affected.",
-  "Extra node argument when calling a node binary.": "Extra node argument when calling a node binary."
+  "Extra node argument when calling a node binary.": "Extra node argument when calling a node binary.",
+  "Always spawn a child process to execute the command.": "Always spawn a child process to execute the command."
 }

--- a/parse-args.js
+++ b/parse-args.js
@@ -179,6 +179,10 @@ function yargsParser (argv, defaultNpm) {
       type: 'string',
       describe: Y()`Location of the npm cache.`
     })
+    .option('always-spawn', {
+      describe: Y()`Always spawn a child process to execute the command.`,
+      type: 'boolean'
+    })
     .option('no-install', {
       type: 'boolean',
       describe: Y()`Skip installation if a package is missing.`


### PR DESCRIPTION
This PR adds an `in-process` opt-in to avoid defaulting to running in the same process as `npx`. Running in process causes the promise to resolve quicker and creates problems with packages that tie-in to `process.on('exit')` or call `process.exit()`. Related to https://github.com/npm/npm/pull/20303.

**Update:**

I can also flip this so instead of opting-in to `in-process` the user could opt-in to `child` process.

**Update:**

Flipped to adding a `--always-spawn` option.