### PR TITLE
fix(windows): Allow spaces in the node path when using --node-arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,7 +283,7 @@ function execCommand (_existing, argv) {
         nargs = nargs.reduce((acc, arg) => {
           return acc.concat(arg.split(/\s+/))
         }, [])
-        cmd = process.argv[0]
+        cmd = child.escapeArg(process.argv[0], true)
         opts = Object.assign({}, argv, {
           cmdOpts: nargs.concat([existing], argv.cmdOpts || [])
         })

--- a/test/index.js
+++ b/test/index.js
@@ -294,3 +294,16 @@ test('nice error message when no binaries on windows', {
     t.end()
   })
 })
+
+test('--node-arg works on Windows', {
+  skip: !isWindows && 'Only on Windows does --node-arg have issues'
+}, t => {
+  return child.spawn('node', [
+    NPX_ESC, '--quiet',
+    '--node-arg', '--no-deprecation',
+    'echo-cli', 'hewwo'
+  ], {stdio: 'pipe'}).then(res => {
+    t.equal(res.stdout.trim(), 'hewwo')
+    t.end()
+  })
+})


### PR DESCRIPTION
Fixes: #170 

Added a call to `child.escapeArg()` in the block that handles `--node-arg` command options.