### PR TITLE
fix: spawn child processes with node without relying on the shebang.

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,6 +253,7 @@ function installPackages (specs, prefix, opts) {
 module.exports._execCommand = execCommand
 function execCommand (_existing, argv) {
   return findNodeScript(_existing, argv).then(existing => {
+    const argvCmdOpts = argv.cmdOpts || []
     if (existing && !argv.alwaysSpawn && !argv.nodeArg && !argv.shell && existing !== process.argv[1]) {
       const Module = require('module')
       // let it take over the process. This means we can skip node startup!
@@ -263,31 +264,35 @@ function execCommand (_existing, argv) {
       process.argv = [
         process.argv[0], // Current node binary
         existing // node script path. `runMain()` will set this as the new main
-      ].concat(argv.cmdOpts) // options for the cmd itself
+      ].concat(argvCmdOpts) // options for the cmd itself
       Module.runMain() // ✨MAGIC✨. Sorry-not-sorry
     } else if (!existing && argv.nodeArg && argv.nodeArg.length) {
       throw new Error(Y()`ERROR: --node-arg/-n can only be used on packages with node scripts.`)
     } else {
       let cmd = existing
-      let opts = argv
-      if (existing && argv.nodeArg && argv.nodeArg.length) {
+      let cmdOpts = argvCmdOpts
+      if (existing) {
+        cmd = process.argv[0]
+        if (process.platform === 'win32') {
+          cmd = child.escapeArg(cmd, true)
+        }
         // If we know we're running a run script and we got a --node-arg,
         // we need to fudge things a bit to get them working right.
-        let nargs = argv.nodeArg
-        if (typeof nargs === 'string') {
-          nargs = [nargs]
+        cmdOpts = argv.nodeArg
+        if (cmdOpts) {
+          cmdOpts = Array.isArray(cmdOpts) ? cmdOpts : [cmdOpts]
+        } else {
+          cmdOpts = []
         }
         // It's valid for a single arg to be a string of multiple
         // space-separated node args.
         // Example: `$ npx -n '--inspect --harmony --debug' ...`
-        nargs = nargs.reduce((acc, arg) => {
+        cmdOpts = cmdOpts.reduce((acc, arg) => {
           return acc.concat(arg.split(/\s+/))
         }, [])
-        cmd = child.escapeArg(process.argv[0], true)
-        opts = Object.assign({}, argv, {
-          cmdOpts: nargs.concat([existing], argv.cmdOpts || [])
-        })
+        cmdOpts = cmdOpts.concat(existing, argvCmdOpts)
       }
+      const opts = Object.assign({}, argv, { cmdOpts })
       return child.runCommand(cmd, opts).catch(err => {
         if (err.isOperational && err.exitCode) {
           // At this point, we want to treat errors from the child as if


### PR DESCRIPTION
This PR attempts to fix the issue reported in https://github.com/zkat/npx/pull/172#issuecomment-380912838 by running commands through Node in much the same way as when passed a `nodeArg`, or when run in the `npx` process. The only time it doesn't run through Node is when `existing` is falsey, in which case it will be allowed to pass through unchanged to `child.runCommand` so it errors appropriately.