### PR TITLE
feat: set NPX_CLI_JS environment variable for spawned commands.

### DIFF
--- a/child.js
+++ b/child.js
@@ -8,6 +8,7 @@ function runCommand (command, opts) {
   const cmd = opts.call || command || opts.command
   const copts = (opts.call ? [] : opts.cmdOpts) || []
   return spawn(cmd, copts, {
+    env: opts.env || null,
     shell: opts.shell || !!opts.call,
     stdio: opts.stdio || 'inherit'
   }).catch(err => {

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,7 @@ const main = require('../index.js')
 
 const isWindows = process.platform === 'win32'
 
+const NPX_CLI_JS = path.resolve(__dirname, '..', 'index.js')
 const NPX_PATH = path.resolve(__dirname, 'util', 'npx-bin.js')
 const NPM_PATH = path.resolve(__dirname, '..', 'node_modules', 'npm', 'bin', 'npm-cli.js')
 
@@ -43,6 +44,7 @@ test('npx --always-spawn resolves promise after command is executed', t => {
       const opts = args[1]
       t.ok(command.includes('node'), 'node executes the command')
       t.equal(opts.alwaysSpawn, true, 'set opts.alwaysSpawn')
+      t.same(opts.env, { NPX_CLI_JS }, 'sets NPX_CLI_JS environment variable')
       t.equal(opts.command, 'echo-cli', 'set opts.command')
       t.ok(opts.cmdOpts[0].includes('echo-cli'), 'set opts.cmdOpts[0]')
       t.equal(opts.cmdOpts[1], 'hewwo', 'set opts.cmdOpts[1]')


### PR DESCRIPTION
This PR forwards/sets the `NPX_CLI_JS` environment variable to [match invocations through `npm`](https://github.com/npm/npm/blob/ee147fbbca6f2707d3b16f4fa78f4c4606b2d9b1/bin/npx#L16).

On Windows there is no mechanism to detect being invoked by `npx`. This PR would make the mechanism consistent across platforms and invocation techniques _(via `npm` install or `libnpx`)_.

This allows commands invoked by `npx` to detect `npx` and customize functionality. For example `create-esm` can detect `npx` is running it and defer to `npm init` instead of `yarn init`.
