### PR TITLE
feat(node-path): append temp packages to $NODE_PATH

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,9 @@ function ensurePackages (specs, opts) {
     const bins = process.platform === 'win32'
       ? prefix
       : path.join(prefix, 'bin')
+    const libs = process.platform === 'win32'
+      ? path.join(prefix, 'node_modules')
+      : path.join(prefix, 'lib', 'node_modules')
     const rimraf = require('rimraf')
     process.on('exit', () => rimraf.sync(prefix))
     return promisify(rimraf)(bins).then(() => {
@@ -156,6 +159,7 @@ function ensurePackages (specs, opts) {
       // This is intentional, since npx assumes that if you went through
       // the trouble of doing `-p`, you're rather have that one. Right? ;)
       process.env.PATH = `${bins}${path.delimiter}${process.env.PATH}`
+      process.env.NODE_PATH = `${libs}${path.delimiter}${process.env.NODE_PATH || ''}`
       if (!info) { info = {} }
       info.prefix = prefix
       info.bin = bins


### PR DESCRIPTION
Ref: #160

This makes it so you can do `npx -p lodash node -r lodash` when lodash is not
already installed. One big downside of this patch is that because of the semantics
of that node feature, NODE_PATH will always be treated as a _fallback_. That is, if
you already have one version of lodash installed in a local npm project you're
currently in the directory of, you won't be able to override it with the
temporary install.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
