### PR TITLE
Escape path-related npm options on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ function getNpmCache (opts) {
 module.exports._buildArgs = buildArgs
 function buildArgs (specs, prefix, opts) {
   const args = ['install'].concat(specs)
-  args.push('--global', '--prefix', prefix)
+  args.push('--global', '--prefix', process.platform === 'win32' ? `"${prefix}"` : prefix)
   if (opts.cache) args.push('--cache', opts.cache)
   if (opts.userconfig) args.push('--userconfig', opts.userconfig)
   args.push('--loglevel', 'error', '--json')

--- a/test/index.js
+++ b/test/index.js
@@ -158,7 +158,7 @@ test('installPackages unit', t => {
       NPM_PATH,
       'install', 'installme@latest', 'file:foo',
       '--global',
-      '--prefix', 'myprefix',
+      '--prefix', isWindows ? '"myprefix"' : 'myprefix',
       '--loglevel', 'error',
       '--json'
     ], 'args to spawn were correct for installing requested package')


### PR DESCRIPTION
This patch supersedes #138 and adds a bit more escaping, now that I actually managed to wrap my head around what was actually going on, and the different bizarre escaping things related to windows (oh god it's so bad).

I think this should iron out the main issue on Windows _and_ solve some others that were lurking in the shadows, ready to strike.

/cc @brianpeiris @noahleigh 
