### PR TITLE
(Hacky) allow -c to consume extra arguments

### DIFF
--- a/child.js
+++ b/child.js
@@ -6,7 +6,7 @@ const path = require('path')
 module.exports.runCommand = runCommand
 function runCommand (command, opts) {
   const cmd = opts.call || command || opts.command
-  const copts = (opts.call ? [] : opts.cmdOpts) || []
+  const copts = opts.cmdOpts || []
   return spawn(cmd, copts, {
     shell: opts.shell || !!opts.call,
     stdio: opts.stdio || 'inherit'

--- a/parse-args.js
+++ b/parse-args.js
@@ -44,7 +44,24 @@ function parseArgs (argv, defaultNpm) {
     }
   }
   if (cmdIndex) {
-    const parsed = parser.parse(argv.slice(0, cmdIndex))
+    let parsed = parser.parse(argv.slice(0, cmdIndex))
+    if (parsed.call) {
+      const fullParsed = parser.parse(argv)
+      fullParsed.cmdOpts = fullParsed._.slice(2)
+      fullParsed.cmdHadVersion = false
+      if (fullParsed.package) {
+        fullParsed.packageRequested = true
+        if (typeof fullParsed.package === 'string') {
+          fullParsed.package = [fullParsed.package]
+        }
+        const pkg = fullParsed.package
+        fullParsed.p = fullParsed.package = pkg.map(p => npa(p).toString())
+      } else {
+        fullParsed.packageRequested = false
+        fullParsed.p = fullParsed.package = []
+      }
+      return fullParsed
+    }
     const parsedCmd = npa(argv[cmdIndex])
     parsed.command = parsed.package && parsedCmd.type !== 'directory'
       ? argv[cmdIndex]
@@ -163,7 +180,7 @@ function yargsParser (argv, defaultNpm) {
 
   npx [${Y()`options`}] [-p|--package <${Y()`package`}>]... <${Y()`command`}> [${Y()`command-arg`}]...
 
-  npx [${Y()`options`}] -c '<${Y()`command-string`}>'
+  npx [${Y()`options`}] [-p|--package <${Y()`package`}>] -c '<${Y()`command-string`}> [${Y()`command-arg`}]...'
 
   npx --shell-auto-fallback [${Y()`shell`}]
   `

--- a/test/child.js
+++ b/test/child.js
@@ -156,3 +156,19 @@ test('runCommand with opts.call and opts.shell', {
     })
   })
 })
+
+test('runCommand with opts.call and opts.cmdOpts', {
+  skip: process.platform === 'win32' && 'Windows passes different flags to shell'
+}, t => {
+  return child.runCommand(null, {
+    call: 'node',
+    cmdOpts: ['-p', '"1 + 1"'],
+    stdio: 'pipe'
+  }).then(res => {
+    t.deepEqual(res, {
+      code: 0,
+      stdout: '2\n',
+      stderr: ''
+    })
+  })
+})

--- a/test/parse-args.js
+++ b/test/parse-args.js
@@ -88,13 +88,26 @@ test('parses multiple package options', t => {
   t.done()
 })
 
-test('does not parse -c', t => {
+test('does not parse -c, stores as call', t => {
   const parsed = mockParse('-c', 'foo a b')
   t.deepEqual(parsed.command, null, 'stays unparsed')
   t.deepEqual(parsed.package, [])
   t.equal(parsed.packageRequested, false)
   t.equal(parsed.cmdHadVersion, false)
+  t.equal(parsed.call, 'foo a b')
   t.deepEqual(parsed.cmdOpts, null)
+  t.done()
+})
+
+test('collects extra arguments when using -c', t => {
+  const parsed = mockParse('-c', 'foo', 'a', '"x y"')
+  console.log(parsed)
+  t.deepEqual(parsed.command, null, 'stays unparsed')
+  t.deepEqual(parsed.package, [])
+  t.equal(parsed.packageRequested, false)
+  t.equal(parsed.cmdHadVersion, false)
+  t.equal(parsed.call, 'foo')
+  t.deepEqual(parsed.cmdOpts, ['a', '"x y"'])
   t.done()
 })
 
@@ -104,7 +117,19 @@ test('uses -p even with -c', t => {
   t.deepEqual(parsed.package, ['bar@latest'])
   t.equal(parsed.packageRequested, true)
   t.equal(parsed.cmdHadVersion, false)
+  t.equal(parsed.call, 'foo a b')
   t.deepEqual(parsed.cmdOpts, null)
+  t.done()
+})
+
+test('uses -p even with -c and extra arguments', t => {
+  const parsed = mockParse('-c', 'foo', '-p', 'bar', 'a', '"x y"')
+  t.deepEqual(parsed.command, null)
+  t.deepEqual(parsed.package, ['bar@latest'])
+  t.equal(parsed.packageRequested, true)
+  t.equal(parsed.cmdHadVersion, false)
+  t.equal(parsed.call, 'foo')
+  t.deepEqual(parsed.cmdOpts, ['a', '"x y"'])
   t.done()
 })
 


### PR DESCRIPTION
This is a proof-of-concept for #184 

I'm not really happy with the implementation here, but I think doing it any tidier would require much more invasive changes into the parse-args code.

I figure I'd post this up now and it'll give something to talk about and decide if this is worth progressing.