### PR TITLE
docs: Fix incorrect CC0 license and add (C) in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Please file any relevant issues [on Github.](https://github.com/zkat/npx)
 
 ## LICENSE
 
-This work is released by its authors into the public domain under CC0-1.0. See `LICENSE.md` for details.
+This work is copyrighted by npm, Inc. and distributed under the ISC license. See `LICENSE.md` for details.
 
 ## SEE ALSO
 


### PR DESCRIPTION
Commit a617d7bc9b60425ab6b53365a5cc65ff40131be0 changed the license from CC0 to ISC but not in README.md.

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
